### PR TITLE
Make dopen actually launch desktop entries

### DIFF
--- a/src/desktop/execute.rs
+++ b/src/desktop/execute.rs
@@ -23,6 +23,7 @@ pub struct ExecContext<'a> {
     args: &'a [String],
 }
 
+#[derive(Debug)]
 pub enum Error {
     NoCommand,
     IncompleteEscape,

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,9 +11,29 @@ mod desktop;
 
 use desktop::*;
 use std::env;
+use std::process;
 
 fn main() {
-    let path = env::args().nth(1).unwrap();
-    let result = parse_file(path).unwrap();
-    println!("Parsed: {:?}", result);
+    let mut args = env::args();
+    let _binary = args.next();
+    let path = match args.next() {
+        Some(path) => path,
+        None => {
+            eprintln!("usage: dopen <desktop file> [arguments...]");
+            process::exit(1);
+        }
+    };
+    let exec_args: Vec<String> = args.collect();
+    let entry = match parse_file(&path) {
+        Ok(entry) => entry,
+        Err(err) => {
+            eprintln!("{}", err);
+            process::exit(1);
+        }
+    };
+
+    if let Err(err) = execute(&entry, &exec_args, Some(path)) {
+        eprintln!("Failed to execute desktop file: {:?}", err);
+        process::exit(1);
+    }
 }


### PR DESCRIPTION
/claim #3

This changes the CLI entry point from parsing-only to execute the desktop entry through the existing launcher path. It now parses the .desktop file, passes through extra CLI arguments, and reports parse/execute failures on stderr instead of printing the parsed structure.

Validation:
- static review of the changed Rust files
- 